### PR TITLE
don't leak language selector code

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -75,7 +75,7 @@
             li
               = link_to t('menu.wiki'), 'http://ouiki.ouishare.net/', target: :blank
             li
-              a href="http://magazine.ouishare.net/# @current_language.slug == 'en' ? '' : @current_language.slug" target="blank" = t('menu.magazine')
+              a href="http://magazine.ouishare.net/ target="blank" = t('menu.magazine')
 
         li
           .header-main-logo


### PR DESCRIPTION
Is this language selector code supposed to be in the URL fragment here? It seemed unusual so I thought I'd flag it. If it's intentional then I apologize for the noise! :-)

Here's the link I see on the "Magazine" link on the dropdown:

`http://magazine.ouishare.net/# @current_language.slug == 'en' ? '' : @current_language.slug`

![screen shot 2016-02-17 at 12 30 18 pm](https://cloud.githubusercontent.com/assets/134455/13118503/7352cacc-d572-11e5-9320-498e90dc32ae.png)
